### PR TITLE
Wrench instead fs-extra, to allow recursive copies with symlinks

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -8,7 +8,7 @@
 /**
  * Dependencies
  */
-var extra   = require('fs-extra'),
+var wrench  = require('wrench'),
     fs      = require('fs');
 
 /**
@@ -28,8 +28,13 @@ module.exports = function (template, name, callback) {
     if (!fs.existsSync(source)) return callback('Template not found.');
     if (fs.existsSync(destination)) return callback('Path already exists.');
 
-    // Copy
-    extra.copy(source, destination, function (err) {
+    wrench.copyDirSyncRecursive(source, destination, {
+       forceDelete: false,       // Whether to overwrite existing directory or not
+       excludeHiddenUnix: false, // Whether to copy hidden Unix files or not (preceding .)
+       preserveFiles: false,     // If we're overwriting something and the file already exists, keep the existing
+       inflateSymlinks: true,    // Whether to follow symlinks or not when copying files
+    }, function(err)
+    {
         callback(err, destination);
     });
 };

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -9,7 +9,7 @@
  * Dependencies
  */
 var colors  = require('colors'),
-    extra   = require('fs-extra'),
+    wrench  = require('wrench'),
     fs      = require('fs');
 
 /**
@@ -21,6 +21,11 @@ module.exports = function (callback) {
 
     fs.exists(target, function (exists) {
         if (exists) console.log('Re-initalizing default templates...'.yellow);
-        extra.copy(source, target, callback);
+        wrench.copyDirSyncRecursive(source, target, {
+            forceDelete      : true,  // Whether to overwrite existing directory or not
+            excludeHiddenUnix: false, // Whether to copy hidden Unix files or not (preceding .)
+            preserveFiles    : false, // If we're overwriting something and the file already exists, keep the existing
+            inflateSymlinks  : true   // Whether to follow symlinks or not when copying files
+        }, callback);
     });
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "~0.2.9",
     "colors": "~0.6.2",
     "findit": "~0.1.2",
-    "fs-extra": "~0.6.3",
+    "wrench": "~1.5.4"
     "prompt": "~0.2.11",
     "optimist": "~0.6.0",
     "replace": "~0.2.7"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "~0.2.9",
     "colors": "~0.6.2",
     "findit": "~0.1.2",
-    "wrench": "~1.5.4"
+    "wrench": "~1.5.4",
     "prompt": "~0.2.11",
     "optimist": "~0.6.0",
     "replace": "~0.2.7"


### PR DESCRIPTION
I wasn't able to copy template which actually was a symlink to my project, fs-extra doesn't seem to have such feature, plus wrench adds some more possibilities - like filtering, whitelisting, exclude, etc. https://github.com/ryanmcgrath/wrench-js
